### PR TITLE
Add initial location sampling utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
+# Random Location Sampler
 
+This project demonstrates how to select a random geographic point with a probability proportional to population density.
+
+The approach is:
+
+1. Load a dataset of administrative boundaries with associated population figures. Natural Earth `ne_10m_admin_0` is a good starting dataset and includes a `POP_EST` field.
+2. Choose a region (e.g. a country) at random with probability proportional to its population.
+3. Optionally repeat the process with sub‑regions if more granular data (such as states or provinces) is available.
+4. Generate a random coordinate within the selected polygon.
+
+The script `location_sampler.py` implements a basic version of this method using `geopandas` and `shapely`.
+
+```
+python -m location_sampler <path-to-shapefile> [population_field]
+```
+
+Dependencies are listed in `requirements.txt`.

--- a/location_sampler.py
+++ b/location_sampler.py
@@ -1,0 +1,59 @@
+import random
+from pathlib import Path
+from typing import Optional
+
+import geopandas as gpd
+from shapely.geometry import Polygon, MultiPolygon
+
+
+def random_point_within(poly: Polygon) -> tuple[float, float]:
+    minx, miny, maxx, maxy = poly.bounds
+    while True:
+        p = gpd.points_from_xy([random.uniform(minx, maxx)], [random.uniform(miny, maxy)])[0]
+        if poly.contains(p):
+            return p.x, p.y
+
+
+def random_location(shapefile: str, population_field: str = "POP_EST") -> tuple[str, float, float]:
+    """Choose a random location weighted by population.
+
+    Parameters
+    ----------
+    shapefile: str
+        Path to a polygon dataset (e.g. Natural Earth countries).
+    population_field: str
+        Field in the dataset containing population numbers.
+
+    Returns
+    -------
+    tuple[str, float, float]
+        A tuple of the chosen region name, longitude, and latitude.
+    """
+    gdf = gpd.read_file(shapefile)
+    if population_field not in gdf.columns:
+        raise ValueError(f"population field '{population_field}' not in dataset")
+    populations = gdf[population_field].astype(float)
+    weights = populations / populations.sum()
+    region = gdf.sample(weights=weights).iloc[0]
+
+    geom = region.geometry
+    if isinstance(geom, MultiPolygon):
+        # choose one polygon from the multi polygon weighted by area
+        areas = [p.area for p in geom.geoms]
+        poly = random.choices(list(geom.geoms), weights=areas)[0]
+    else:
+        poly = geom
+
+    lon, lat = random_point_within(poly)
+    return region.get("NAME", region.index), lon, lat
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Sample a random location weighted by population")
+    parser.add_argument("shapefile", help="Path to shapefile or GeoPackage containing polygons")
+    parser.add_argument("population_field", nargs="?", default="POP_EST", help="Column containing population values")
+    args = parser.parse_args()
+
+    name, lon, lat = random_location(args.shapefile, args.population_field)
+    print(f"{name}: {lon:.6f}, {lat:.6f}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+geopandas
+shapely

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,6 @@
+import importlib, os, sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+def test_import():
+    assert importlib.import_module('location_sampler')


### PR DESCRIPTION
## Summary
- set up README with basic approach to sampling a location weighted by population
- implement `location_sampler.py` for population-weighted sampling using `geopandas`
- capture dependencies in `requirements.txt`
- add a minimal pytest to ensure the module imports

## Testing
- `python3 -m pip install --quiet -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab65c754083279aba088ad63e6765