### PR TITLE
Add dataset download helper and optional shapefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore downloaded data
+/data/
+*.zip

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ This project demonstrates how to select a random geographic point with a probabi
 
 The approach is:
 
-1. Load a dataset of administrative boundaries with associated population figures. Natural Earth `ne_10m_admin_0` is a good starting dataset and includes a `POP_EST` field.
+1. Load a dataset of administrative boundaries with associated population figures. The helper in `scripts/data_utils.py` will automatically download the Natural Earth `ne_10m_admin_0` dataset.
 2. Choose a region (e.g. a country) at random with probability proportional to its population.
 3. Optionally repeat the process with sub‑regions if more granular data (such as states or provinces) is available.
 4. Generate a random coordinate within the selected polygon.
 
-The script `location_sampler.py` implements a basic version of this method using `geopandas` and `shapely`.
+The script `location_sampler.py` implements a basic version of this method using `geopandas` and `shapely`. If no shapefile is provided, the Natural Earth countries dataset is downloaded automatically the first time.
 
 ```
-python -m location_sampler <path-to-shapefile> [population_field]
+python -m location_sampler [path-to-shapefile] [population_field]
 ```
+
+Running without arguments will download the Natural Earth dataset to the `data/` directory and sample from it.
 
 Dependencies are listed in `requirements.txt`.

--- a/scripts/data_utils.py
+++ b/scripts/data_utils.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+import urllib.request
+import zipfile
+from pathlib import Path
+
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+DATA_DIR.mkdir(exist_ok=True)
+
+COUNTRIES_URL = (
+    "https://naturalearth.s3.amazonaws.com/10m_cultural/ne_10m_admin_0_countries.zip"
+)
+_ZIP_PATH = DATA_DIR / "ne_10m_admin_0_countries.zip"
+_SHAPEFILE = DATA_DIR / "ne_10m_admin_0_countries.shp"
+
+
+def ensure_countries_dataset() -> str:
+    """Download and extract the Natural Earth countries dataset if needed.
+
+    Returns
+    -------
+    str
+        Path to the extracted shapefile.
+    """
+    if not _SHAPEFILE.exists():
+        if not _ZIP_PATH.exists():
+            urllib.request.urlretrieve(COUNTRIES_URL, _ZIP_PATH)
+        with zipfile.ZipFile(_ZIP_PATH) as zf:
+            zf.extractall(DATA_DIR)
+    return str(_SHAPEFILE)

--- a/tests/test_random_location.py
+++ b/tests/test_random_location.py
@@ -1,0 +1,15 @@
+from location_sampler import random_location
+from scripts.data_utils import ensure_countries_dataset
+
+
+def test_random_location_builtin():
+    # Use an explicit shapefile path
+    shapefile = ensure_countries_dataset()
+    name, lon, lat = random_location(shapefile, "POP_EST")
+    assert isinstance(name, str) and isinstance(lon, float) and isinstance(lat, float)
+
+
+def test_random_location_download():
+    # call without shapefile to trigger dataset download
+    name, lon, lat = random_location()
+    assert isinstance(name, str) and isinstance(lon, float) and isinstance(lat, float)


### PR DESCRIPTION
## Summary
- add helper script to download Natural Earth countries data
- default `random_location` to download dataset if no shapefile is provided
- ignore downloaded data with `.gitignore`
- document new behaviour in README
- test `random_location` with explicit and default datasets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab872d8708327ad5909646a0746f0